### PR TITLE
Feat/fasterer

### DIFF
--- a/base36.go
+++ b/base36.go
@@ -103,8 +103,9 @@ func DecodeString(s string) ([]byte, error) {
 		zcnt++
 	}
 
-	outi := make([]uint32, (len(s)+3)/4)
-	binu := make([]byte, (len(s)+3)*3)
+	// the 32bit algo stretches the result up to 2 times
+	binu := make([]byte, 2*(((len(s))*179/277)+1)) // no more than 84 bytes when len(s) <= 64
+	outi := make([]uint32, (len(s)+3)/4)           // no more than 16 bytes when len(s) <= 64
 
 	for _, r := range s {
 		if r > maxDigitOrdinal || revAlphabet[r] > maxDigitValueB36 {

--- a/base36.go
+++ b/base36.go
@@ -14,7 +14,7 @@ import (
 
 const UcAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const LcAlphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
-const maxDigitOrdinal = byte('z')
+const maxDigitOrdinal = 'z'
 const maxDigitValueB36 = 35
 
 var revAlphabet [maxDigitOrdinal + 1]byte
@@ -103,26 +103,23 @@ func DecodeString(s string) ([]byte, error) {
 		return nil, fmt.Errorf("can not decode zero-length string")
 	}
 
-	var zcnt int
-
-	for i := 0; i < len(s) && s[i] == '0'; i++ {
+	zcnt := 0
+	for zcnt < len(s) && s[zcnt] == '0' {
 		zcnt++
 	}
-
-	var t, c uint64
 
 	outi := make([]uint32, (len(s)+3)/4)
 	binu := make([]byte, (len(s)+3)*3)
 
 	for _, r := range s {
-		if r > rune(maxDigitOrdinal) || revAlphabet[r] > maxDigitValueB36 {
+		if r > maxDigitOrdinal || revAlphabet[r] > maxDigitValueB36 {
 			return nil, fmt.Errorf("invalid base36 character (%q)", r)
 		}
 
-		c = uint64(revAlphabet[r])
+		c := uint64(revAlphabet[r])
 
 		for j := len(outi) - 1; j >= 0; j-- {
-			t = uint64(outi[j])*36 + c
+			t := uint64(outi[j])*36 + c
 			c = (t >> 32)
 			outi[j] = uint32(t & 0xFFFFFFFF)
 		}
@@ -134,20 +131,21 @@ func DecodeString(s string) ([]byte, error) {
 		mask = 32
 	}
 	mask -= 8
-	var j, cnt int
-	for j, cnt = 0, 0; j < len(outi); j++ {
+
+	outidx := 0
+	for j := 0; j < len(outi); j++ {
 		for mask < 32 { // loop relies on uint overflow
-			binu[cnt] = byte(outi[j] >> mask)
+			binu[outidx] = byte(outi[j] >> mask)
 			mask -= 8
-			cnt++
+			outidx++
 		}
 		mask = 24
 	}
 
 	for n := zcnt; n < len(binu); n++ {
 		if binu[n] > 0 {
-			return binu[n-zcnt : cnt], nil
+			return binu[n-zcnt : outidx], nil
 		}
 	}
-	return binu[:cnt], nil
+	return binu[:outidx], nil
 }

--- a/base36.go
+++ b/base36.go
@@ -80,11 +80,7 @@ func encode(inBuf []byte, al string) string {
 	vBuf := out[stopIdx-zcnt:]
 	bufsz = len(vBuf)
 	for idx = 0; idx < bufsz; idx++ {
-		if idx < zcnt {
-			out[idx] = '0'
-		} else {
-			out[idx] = al[vBuf[idx]]
-		}
+		out[idx] = al[vBuf[idx]]
 	}
 
 	return string(out[:bufsz])
@@ -119,7 +115,6 @@ func DecodeString(s string) ([]byte, error) {
 			c = (t >> 32)
 			outi[j] = uint32(t & 0xFFFFFFFF)
 		}
-
 	}
 
 	mask := (uint(len(s)%4) * 8)
@@ -138,10 +133,13 @@ func DecodeString(s string) ([]byte, error) {
 		mask = 24
 	}
 
-	for n := zcnt; n < len(binu); n++ {
-		if binu[n] > 0 {
-			return binu[n-zcnt : outidx], nil
+	// find the most significant byte post-decode, if any
+	for msb := zcnt; msb < outidx; msb++ {
+		if binu[msb] > 0 {
+			return binu[msb-zcnt : outidx : outidx], nil
 		}
 	}
-	return binu[:outidx], nil
+
+	// it's all zeroes
+	return binu[:outidx:outidx], nil
 }

--- a/base36_test.go
+++ b/base36_test.go
@@ -77,10 +77,13 @@ func TestPermute(t *testing.T) {
 }
 
 var benchmarkBuf [36]byte // typical CID size
+var benchmarkDecodeTgt string
+
 var benchmarkCodecs []string
 
 func init() {
 	rand.Read(benchmarkBuf[:])
+	benchmarkDecodeTgt = testEncoders[0](benchmarkBuf[:])
 }
 
 func BenchmarkRoundTrip(b *testing.B) {
@@ -120,10 +123,9 @@ func BenchmarkEncode(b *testing.B) {
 func BenchmarkDecode(b *testing.B) {
 	b.ResetTimer()
 
-	enc := testEncoders[0](benchmarkBuf[:])
 	b.Run("Decoding", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			DecodeString(enc)
+			DecodeString(benchmarkDecodeTgt)
 		}
 	})
 }


### PR DESCRIPTION

<img width="364" alt="image" src="https://user-images.githubusercontent.com/356110/82735921-bbe63b00-9d25-11ea-97ef-ed4aee73ae43.png">

The core change is this https://github.com/multiformats/go-base36/blob/986b8a84d74dd7192b179abe4b77e1de66ab7549/base36.go#L50-L59 We now allocate just as much as we need, and iterate over the buffer in place: once to breakdown into values, and a second time to recode into an alphabet.


- before
```
go-multibase$ go test ./... -count=1 -bench .
goos: darwin
goarch: amd64
pkg: github.com/multiformats/go-multibase
BenchmarkRoundTrip/base36-8         	  326816	      3599 ns/op
BenchmarkRoundTrip/base36upper-8    	  332366	      3571 ns/op
BenchmarkRoundTrip/base58btc-8      	  481983	      2551 ns/op
BenchmarkRoundTrip/base58flickr-8   	  470001	      2556 ns/op
BenchmarkEncode/base36-8            	  435662	      2788 ns/op
BenchmarkEncode/base36upper-8       	  440614	      2788 ns/op
BenchmarkEncode/base58btc-8         	  770272	      1568 ns/op
BenchmarkEncode/base58flickr-8      	  700389	      1562 ns/op
BenchmarkDecode/base36-8            	 1606472	       745 ns/op
BenchmarkDecode/base36upper-8       	 1614858	       744 ns/op
BenchmarkDecode/base58btc-8         	 1245900	       952 ns/op
BenchmarkDecode/base58flickr-8      	 1259892	       956 ns/op
PASS
```

- after
```
go-multibase$ go test ./... -count=1 -bench .
goos: darwin
goarch: amd64
pkg: github.com/multiformats/go-multibase
BenchmarkRoundTrip/base36-8         	  432175	      2750 ns/op
BenchmarkRoundTrip/base36upper-8    	  436525	      2723 ns/op
BenchmarkRoundTrip/base58btc-8      	  466893	      2553 ns/op
BenchmarkRoundTrip/base58flickr-8   	  475454	      2547 ns/op
BenchmarkEncode/base36-8            	  601210	      1933 ns/op
BenchmarkEncode/base36upper-8       	  629655	      1938 ns/op
BenchmarkEncode/base58btc-8         	  791280	      1572 ns/op
BenchmarkEncode/base58flickr-8      	  795505	      1555 ns/op
BenchmarkDecode/base36-8            	 1558412	       766 ns/op
BenchmarkDecode/base36upper-8       	 1561417	       762 ns/op
BenchmarkDecode/base58btc-8         	 1250644	       954 ns/op
BenchmarkDecode/base58flickr-8      	 1263541	       954 ns/op
PASS
```

P.S. If you look closely you see that the decoding became marginally slower. To the best of my ability to reason it has to do with the *total* compiled object size. That is - if you **revert** https://github.com/multiformats/go-base36/commit/986b8a84d74, then the decoding number goes back to where it was, even though the reverted commit **does not touch the decode method** 🤯 