### PR TITLE
Address `staticcheck` issue

### DIFF
--- a/base36_test.go
+++ b/base36_test.go
@@ -79,8 +79,6 @@ func TestPermute(t *testing.T) {
 var benchmarkBuf [36]byte // typical CID size
 var benchmarkDecodeTgt string
 
-var benchmarkCodecs []string
-
 func init() {
 	rand.Read(benchmarkBuf[:])
 	benchmarkDecodeTgt = testEncoders[0](benchmarkBuf[:])


### PR DESCRIPTION
Remove unused variable in test that caused U1000

Relates to:
- https://github.com/orgs/ipfs/projects/12#card-58209321